### PR TITLE
Update footer to display opening hours from Restaurant model

### DIFF
--- a/home/context_processors.py
+++ b/home/context_processors.py
@@ -10,9 +10,19 @@ def current_year(request):
         address = f"{location.address}, {location.city}, {location.state} {location.zip_code}"
     else:
         address = getattr(settings, 'RESTAURANT_ADDRESS', '123 Main St, Springfield, USA')
+    # Get opening hours from the Restaurant model if available
+    if restaurant and restaurant.opening_hours:
+        # Format opening hours as a string for display
+        hours_dict = restaurant.opening_hours
+        if isinstance(hours_dict, dict):
+            hours_str = ", ".join(f"{day}: {hours}" for day, hours in hours_dict.items())
+        else:
+            hours_str = str(hours_dict)
+    else:
+        hours_str = getattr(settings, 'RESTAURANT_HOURS', 'Mon-Fri: 11am-9pm, Sat-Sun: 10am-10pm')
     return {
         'current_year': datetime.now().year,
-        'restaurant_hours': getattr(settings, 'RESTAURANT_HOURS', 'Mon-Fri: 11am-9pm, Sat-Sun: 10am-10pm'),
+        'restaurant_hours': hours_str,
         'restaurant_name': getattr(settings, 'RESTAURANT_NAME', 'Perpex Bistro'),
         'restaurant_address': address,
     }

--- a/home/context_processors.py
+++ b/home/context_processors.py
@@ -1,6 +1,16 @@
 from datetime import datetime
 from django.conf import settings
+
 from home.models import Restaurant, RestaurantLocation
+
+def format_opening_hours(hours_dict):
+    # Standard order for days of the week
+    days_order = [
+        "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"
+    ]
+    if not isinstance(hours_dict, dict):
+        return str(hours_dict)
+    return ", ".join(f"{day}: {hours_dict.get(day, 'Closed')}" for day in days_order)
 
 def current_year(request):
     # Try to get the first restaurant and its location
@@ -12,12 +22,7 @@ def current_year(request):
         address = getattr(settings, 'RESTAURANT_ADDRESS', '123 Main St, Springfield, USA')
     # Get opening hours from the Restaurant model if available
     if restaurant and restaurant.opening_hours:
-        # Format opening hours as a string for display
-        hours_dict = restaurant.opening_hours
-        if isinstance(hours_dict, dict):
-            hours_str = ", ".join(f"{day}: {hours}" for day, hours in hours_dict.items())
-        else:
-            hours_str = str(hours_dict)
+        hours_str = format_opening_hours(restaurant.opening_hours)
     else:
         hours_str = getattr(settings, 'RESTAURANT_HOURS', 'Mon-Fri: 11am-9pm, Sat-Sun: 10am-10pm')
     return {


### PR DESCRIPTION
- Modify context processor to fetch opening_hours from the Restaurant model
- Footer and all pages now show dynamic hours from the database if set
- Falls back to settings value if no hours are set in the model