### PR TITLE
Add reusable TaskQueue class for project-wide FIFO task management

### DIFF
--- a/restaurant_management/utils/task_queue.py
+++ b/restaurant_management/utils/task_queue.py
@@ -1,0 +1,31 @@
+class TaskQueue:
+    """
+    Simple FIFO task queue using a Python list.
+    Methods:
+        enqueue(task): Add a task to the end of the queue.
+        dequeue(): Remove and return the first task in the queue.
+        peek(): View the first task without removing it.
+        is_empty(): Check if the queue is empty.
+        size(): Return the number of tasks in the queue.
+    """
+    def __init__(self):
+        self.queue = []
+
+    def enqueue(self, task):
+        self.queue.append(task)
+
+    def dequeue(self):
+        if self.queue:
+            return self.queue.pop(0)
+        return None
+
+    def peek(self):
+        if self.queue:
+            return self.queue[0]
+        return None
+
+    def is_empty(self):
+        return len(self.queue) == 0
+
+    def size(self):
+        return len(self.queue)

--- a/restaurant_management/utils/task_queue.py
+++ b/restaurant_management/utils/task_queue.py
@@ -1,23 +1,25 @@
+from collections import deque
+
 class TaskQueue:
     """
-    Simple FIFO task queue using a Python list.
+    Simple FIFO task queue using collections.deque for O(1) operations.
     Methods:
         enqueue(task): Add a task to the end of the queue.
-        dequeue(): Remove and return the first task in the queue.
+        dequeue(): Remove and return the first task in the queue. Raises IndexError if empty.
         peek(): View the first task without removing it.
         is_empty(): Check if the queue is empty.
         size(): Return the number of tasks in the queue.
     """
     def __init__(self):
-        self.queue = []
+        self.queue = deque()
 
     def enqueue(self, task):
         self.queue.append(task)
 
     def dequeue(self):
         if self.queue:
-            return self.queue.pop(0)
-        return None
+            return self.queue.popleft()
+        raise IndexError("dequeue from empty queue")
 
     def peek(self):
         if self.queue:


### PR DESCRIPTION
This update introduces a simple, reusable FIFO task queue implemented as a Python class in restaurant_management/utils/task_queue.py. The queue supports enqueue, dequeue, peek, and other basic operations, and is available for use across all apps in the project. This utility lays the foundation for simulating background task processing and helps illustrate core queue concepts used in scalable systems.